### PR TITLE
Configure KSP and migrate Hilt from KAPT

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,9 +2,10 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.ksp) // Added
     id("com.google.gms.google-services")
     id("com.google.dagger.hilt.android")
-    kotlin("kapt")
+    // kotlin("kapt") has been removed
 }
 
 android {
@@ -49,8 +50,8 @@ dependencies {
     implementation(libs.kotlinx.coroutines.play.services)
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.hilt.android)
-    kapt(libs.hilt.android.compiler)
-    kapt(libs.androidx.hilt.compiler)
+    ksp(libs.hilt.android.compiler)
+    ksp(libs.androidx.hilt.compiler)
     implementation(libs.retrofit)
     implementation(libs.converter.gson)
     implementation(libs.logging.interceptor)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.ksp) apply false // New line
     id("com.google.gms.google-services") version "4.4.2" apply false
     id("org.jlleitschuh.gradle.ktlint") version "11.5.0" apply false
     id("com.google.dagger.hilt.android") version "2.48" apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,8 @@ hiltAndroid = "2.51"
 hiltAndroidCompiler = "2.51"
 hiltAndroidGradlePlugin = "2.51"
 hiltCompiler = "1.2.0"
-kotlin = "2.1.0"
+kotlin = "2.1.20"
+ksp = "2.1.20-2.0.1" # New line
 coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
@@ -61,4 +62,5 @@ retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" } # New line
 


### PR DESCRIPTION
This commit addresses a Gradle sync issue caused by an incorrect KSP plugin version.

Changes include:
- Updated Kotlin version from 2.1.0 to 2.1.20 in `gradle/libs.versions.toml` to ensure compatibility with available KSP versions.
- Added KSP plugin (version 2.1.20-2.0.1) to `gradle/libs.versions.toml`.
- Applied KSP plugin in the root `build.gradle.kts` (`apply false`).
- Applied KSP plugin in `app/build.gradle.kts`.
- Migrated Hilt annotation processing from `kapt` to `ksp` in `app/build.gradle.kts` by:
    - Removing the `kotlin-kapt` plugin.
    - Changing `kapt` configurations for Hilt dependencies to `ksp`.

This setup allows your project to use KSP for annotation processing, which can lead to improved build times compared to KAPT.